### PR TITLE
Bumped trim to 1.0.0 to resolve CVE-2020-7753

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Simple key/value pair query-string parsing",
   "version": "2.0.0",
   "dependencies": {
-    "trim": "0.0.1",
+    "trim": "1.0.0",
     "component-type": "1.1.0"
   },
   "browser": {


### PR DESCRIPTION
More details: https://snyk.io/vuln/SNYK-JS-TRIM-1017038