### PR TITLE
Patch fixes prototype pollution issue #17

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.parse = function(str){
     var key = decode(parts[0]);
     var m;
     // Sanitize keys to uppercase to mitigate client-side prototype pollution
-    if (key && ["__proto__", "constructor", "prototype"].includes(key.toLowerCase())) {
+    if (key && ["__proto__", "constructor", "prototype"].indexOf(key.toLowerCase()) > -1) {
       key = key.toUpperCase()
     }
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ exports.parse = function(str){
     var key = decode(parts[0]);
     var m;
     // Sanitize keys to uppercase to mitigate client-side prototype pollution
-    key && ["__proto__", "constructor", "prototype"].includes(key.toLowerCase()) ? key.toUpperCase() : key
+    if (key && ["__proto__", "constructor", "prototype"].includes(key.toLowerCase())) {
+      key = key.toUpperCase()
+    }
 
     if (m = pattern.exec(key)) {
       obj[m[1]] = obj[m[1]] || [];

--- a/index.js
+++ b/index.js
@@ -41,6 +41,22 @@ var decode = function(str) {
 }
 
 /**
+ * Ensure any potential prototype pollution can be sanitized.
+ *
+ * @param {String} str
+ * @return {String}
+ * @api public
+ */
+
+var sanitizeObjKey = function(str) {
+  if (str && ["__proto__", "constructor", "prototype"].indexOf(str.toLowerCase()) > -1) {
+    return str.toUpperCase()
+  }
+
+  return str;
+}
+
+/**
  * Parse the given query `str`.
  *
  * @param {String} str
@@ -59,20 +75,17 @@ exports.parse = function(str){
   var pairs = str.split('&');
   for (var i = 0; i < pairs.length; i++) {
     var parts = pairs[i].split('=');
-    var key = decode(parts[0]);
+    var key = sanitizeObjKey(decode(parts[0]));
     var m;
-    // Sanitize keys to uppercase to mitigate client-side prototype pollution
-    if (key && ["__proto__", "constructor", "prototype"].indexOf(key.toLowerCase()) > -1) {
-      key = key.toUpperCase()
-    }
 
     if (m = pattern.exec(key)) {
-      obj[m[1]] = obj[m[1]] || [];
-      obj[m[1]][m[2]] = decode(parts[1]);
+      var objectKey = sanitizeObjKey(m[1])
+      obj[objectKey] = obj[objectKey] || [];
+      obj[objectKey][m[2]] = decode(parts[1]);
       continue;
     }
 
-    obj[parts[0]] = null == parts[1]
+    obj[key] = null == parts[1]
       ? ''
       : decode(parts[1]);
   }

--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ exports.parse = function(str){
     var parts = pairs[i].split('=');
     var key = decode(parts[0]);
     var m;
+    // Sanitize keys to uppercase to mitigate client-side prototype pollution
+    key && ["__proto__", "constructor", "prototype"].includes(key.toLowerCase()) ? key.toUpperCase() : key
 
     if (m = pattern.exec(key)) {
       obj[m[1]] = obj[m[1]] || [];


### PR DESCRIPTION
Solution as proposed by Johns Hopkins researchers.

If querystring key contains strings that can cause prototype pollution in the browser, e.g. `__proto__`, transform to uppercase.

fixes #17 